### PR TITLE
[CMSA-439] [웅진]  development, stage, production CICD를 통한 자동 구성

### DIFF
--- a/development/main.tf
+++ b/development/main.tf
@@ -82,7 +82,7 @@ module "ui" {
   sg_cidr_block = var.sg_cidr_block
 
   # lc
-  ui_lc = var.ui_lc
+  ui_lt = var.ui_lt
 }
 
 module "api" {
@@ -106,5 +106,5 @@ module "api" {
   sg_cidr_block = var.sg_cidr_block
 
   # lc
-  api_lc = var.api_lc
+  api_lt = var.api_lt
 }

--- a/development/services/api/api-userdata.tpl
+++ b/development/services/api/api-userdata.tpl
@@ -1,0 +1,2 @@
+#!/bin/bash
+java -jar /home/ubuntu/backend-demo-1.0.0-SNAPSHOT.jar &

--- a/development/services/api/asg.tf
+++ b/development/services/api/asg.tf
@@ -1,28 +1,34 @@
-resource "aws_launch_configuration" "api-lc" {
-  name            = "${var.resrc_prefix_nm}-api-lc"
-  image_id        = var.api_lc.id
-  instance_type   = var.api_lc.type
-  key_name        = var.api_lc.key_name
-  security_groups = [ aws_security_group.api-sg.id ]
+resource "aws_launch_template" "api-lt" {
+  name                    = "${var.resrc_prefix_nm}-api-lt"
+  image_id                = var.api_lt.id
+  key_name                = var.api_lt.key_name
+  instance_type           = var.api_lt.type
+  vpc_security_group_ids  = [ aws_security_group.api-sg.id ]
 
-  user_data = <<USER_DATA
-#!/bin/bash
-java -jar /home/ubuntu/backend-demo-1.0.0-SNAPSHOT.jar &
-  USER_DATA
+  user_data = base64encode(templatefile("./services/api/api-userdata.tpl", {}))
 
-  lifecycle { create_before_destroy = true }
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      "Name" = "${var.resrc_prefix_nm}-api-lt"
+    }
+  }
 }
 
 resource "aws_autoscaling_group" "api-asg" {
   name                  = "${var.resrc_prefix_nm}-api-asg"
-  launch_configuration  = aws_launch_configuration.api-lc.id
   vpc_zone_identifier   = [ aws_subnet.api-sn[0].id, aws_subnet.api-sn[1].id ]
+
+  launch_template {
+    id      = aws_launch_template.api-lt.id
+    version = "$Latest"
+  }
 
   target_group_arns     = [ aws_alb_target_group.api-tg8080-a.arn ]
   health_check_type     = "ELB"
 
-  min_size              = var.api_lc.min_size
-  max_size              = var.api_lc.max_size
+  min_size              = var.api_lt.min_size
+  max_size              = var.api_lt.max_size
 
   tag {
     key                 = "Name"

--- a/development/services/api/sg.tf
+++ b/development/services/api/sg.tf
@@ -10,13 +10,6 @@ resource "aws_security_group" "api-sg" {
   }
 
   ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "TCP"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
     from_port   = 8080
     to_port     = 8080
     protocol    = "TCP"

--- a/development/services/api/vars.tf
+++ b/development/services/api/vars.tf
@@ -58,10 +58,10 @@ variable "sg_cidr_block" {
 
 
 # ######################
-# Launch Configuration
+# Launch Template
 # ######################
-# api launch configuration
-variable "api_lc" {
-  description = "api launch configuration"
+# api launch template
+variable "api_lt" {
+  description = "api launch template"
   type = map(string)
 }

--- a/development/services/ui/asg.tf
+++ b/development/services/ui/asg.tf
@@ -1,23 +1,32 @@
-resource "aws_launch_configuration" "ui-lc" {
-  name            = "${var.resrc_prefix_nm}-ui-lc"
-  image_id        = var.ui_lc.id
-  instance_type   = var.ui_lc.type
-  key_name        = var.ui_lc.key_name
-  security_groups = [ aws_security_group.ui-sg.id ]
+resource "aws_launch_template" "ui-lt" {
+  name                    = "${var.resrc_prefix_nm}-ui-lt"
+  image_id                = var.ui_lt.id
+  key_name                = var.ui_lt.key_name
+  instance_type           = var.ui_lt.type
+  vpc_security_group_ids  = [ aws_security_group.ui-sg.id ]
 
-  lifecycle { create_before_destroy = true }
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      "Name" = "${var.resrc_prefix_nm}-ui-lt"
+    }
+  }
 }
 
 resource "aws_autoscaling_group" "ui-asg" {
   name                  = "${var.resrc_prefix_nm}-ui-asg"
-  launch_configuration  = aws_launch_configuration.ui-lc.id
   vpc_zone_identifier   = [ aws_subnet.ui-sn[0].id, aws_subnet.ui-sn[1].id ]
 
+  launch_template {
+    id      = aws_launch_template.ui-lt.id
+    version = "$Latest"
+  }
+  
   target_group_arns     = [ aws_alb_target_group.ui-tg80-a.arn ]
   health_check_type     = "ELB"
 
-  min_size              = var.ui_lc.min_size
-  max_size              = var.ui_lc.max_size
+  min_size              = var.ui_lt.min_size
+  max_size              = var.ui_lt.max_size
 
   tag {
     key                 = "Name"

--- a/development/services/ui/vars.tf
+++ b/development/services/ui/vars.tf
@@ -58,10 +58,10 @@ variable "sg_cidr_block" {
 
 
 # ######################
-# Launch Configuration
+# Launch Template
 # ######################
-# ui launch configuration
-variable "ui_lc" {
-  description = "ui launch configuration"
+# ui launch template
+variable "ui_lt" {
+  description = "ui launch template"
   type = map(string)
 }

--- a/development/terraform.tfvars
+++ b/development/terraform.tfvars
@@ -76,24 +76,24 @@ sg_cidr_block = ["58.151.93.9/32", "58.151.93.2/32"]
 
 
 # ######################
-# Launch Configuration
+# Launch Template
 # ######################
-# ui launch configuration
-ui_lc = {
+# ui launch template
+ui_lt = {
     "id" = "ami-04df341f89c111637"
     "type" = "t3.medium"
     "key_name" = "comp-prod-keypair"
     "min_size" = 1
-    "max_size" = 1
+    "max_size" = 2
 }
 
-# api launch configuration
-api_lc = {
+# api launch template
+api_lt = {
   "id" = "ami-0da1693657fbc1977"
   "type" = "t3.medium"
   "key_name" = "comp-prod-keypair"
   "min_size" = 1
-  "max_size" = 1
+  "max_size" = 2
 }
 
 

--- a/development/terraform.tfvars
+++ b/development/terraform.tfvars
@@ -81,7 +81,7 @@ sg_cidr_block = ["58.151.93.9/32", "58.151.93.2/32"]
 # ui launch template
 ui_lt = {
     "id" = "ami-04df341f89c111637"
-    "type" = "t3.medium"
+    "type" = "t3.small"
     "key_name" = "comp-prod-keypair"
     "min_size" = 1
     "max_size" = 2
@@ -90,7 +90,7 @@ ui_lt = {
 # api launch template
 api_lt = {
   "id" = "ami-0da1693657fbc1977"
-  "type" = "t3.medium"
+  "type" = "t3.small"
   "key_name" = "comp-prod-keypair"
   "min_size" = 1
   "max_size" = 2

--- a/development/variables.tf
+++ b/development/variables.tf
@@ -79,17 +79,17 @@ variable "sg_cidr_block" {
 
 
 # ######################
-# Launch Configuration
+# Launch Template
 # ######################
-# ui launch configuration
-variable "ui_lc" {
-  description = "ui launch configuration"
+# ui launch template
+variable "ui_lt" {
+  description = "ui launch template"
   type = map(string)
 }
 
-# api launch configuration
-variable "api_lc" {
-  description = "api launch configuration"
+# api launch template
+variable "api_lt" {
+  description = "api launch template"
   type = map(string)
 }
 

--- a/production/main.tf
+++ b/production/main.tf
@@ -82,7 +82,7 @@ module "ui" {
   sg_cidr_block = var.sg_cidr_block
 
   # lc
-  ui_lc = var.ui_lc
+  ui_lt = var.ui_lt
 }
 
 module "api" {
@@ -106,5 +106,5 @@ module "api" {
   sg_cidr_block = var.sg_cidr_block
 
   # lc
-  api_lc = var.api_lc
+  api_lt = var.api_lt
 }

--- a/production/services/api/asg.tf
+++ b/production/services/api/asg.tf
@@ -1,28 +1,32 @@
-resource "aws_launch_configuration" "api-lc" {
-  name            = "${var.resrc_prefix_nm}-api-lc"
-  image_id        = var.api_lc.id
-  instance_type   = var.api_lc.type
-  key_name        = var.api_lc.key_name
-  security_groups = [ aws_security_group.api-sg.id ]
+resource "aws_launch_template" "api-lt" {
+  name                    = "${var.resrc_prefix_nm}-api-lt"
+  image_id                = var.api_lt.id
+  key_name                = var.api_lt.key_name
+  instance_type           = var.api_lt.type
+  vpc_security_group_ids  = [ aws_security_group.api-sg.id ]
 
-  user_data = <<USER_DATA
-#!/bin/bash
-java -jar /home/ubuntu/backend-demo-1.0.0-SNAPSHOT.jar &
-  USER_DATA
-
-  lifecycle { create_before_destroy = true }
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      "Name" = "${var.resrc_prefix_nm}-api-lt"
+    }
+  }
 }
 
 resource "aws_autoscaling_group" "api-asg" {
   name                  = "${var.resrc_prefix_nm}-api-asg"
-  launch_configuration  = aws_launch_configuration.api-lc.id
   vpc_zone_identifier   = [ aws_subnet.api-sn[0].id, aws_subnet.api-sn[1].id ]
+
+  launch_template {
+    id      = aws_launch_template.api-lt.id
+    version = "$Latest"
+  }
 
   target_group_arns     = [ aws_alb_target_group.api-tg8080-a.arn ]
   health_check_type     = "ELB"
 
-  min_size              = var.api_lc.min_size
-  max_size              = var.api_lc.max_size
+  min_size              = var.api_lt.min_size
+  max_size              = var.api_lt.max_size
 
   tag {
     key                 = "Name"

--- a/production/services/api/vars.tf
+++ b/production/services/api/vars.tf
@@ -58,10 +58,10 @@ variable "sg_cidr_block" {
 
 
 # ######################
-# Launch Configuration
+# Launch Template
 # ######################
-# api launch configuration
-variable "api_lc" {
-  description = "api launch configuration"
+# api launch template
+variable "api_lt" {
+  description = "api launch template"
   type = map(string)
 }

--- a/production/services/ui/asg.tf
+++ b/production/services/ui/asg.tf
@@ -1,23 +1,32 @@
-resource "aws_launch_configuration" "ui-lc" {
-  name            = "${var.resrc_prefix_nm}-ui-lc"
-  image_id        = var.ui_lc.id
-  instance_type   = var.ui_lc.type
-  key_name        = var.ui_lc.key_name
-  security_groups = [ aws_security_group.ui-sg.id ]
+resource "aws_launch_template" "ui-lt" {
+  name                    = "${var.resrc_prefix_nm}-ui-lt"
+  image_id                = var.ui_lt.id
+  key_name                = var.ui_lt.key_name
+  instance_type           = var.ui_lt.type
+  vpc_security_group_ids  = [ aws_security_group.ui-sg.id ]
 
-  lifecycle { create_before_destroy = true }
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      "Name" = "${var.resrc_prefix_nm}-ui-lt"
+    }
+  }
 }
 
 resource "aws_autoscaling_group" "ui-asg" {
   name                  = "${var.resrc_prefix_nm}-ui-asg"
-  launch_configuration  = aws_launch_configuration.ui-lc.id
   vpc_zone_identifier   = [ aws_subnet.ui-sn[0].id, aws_subnet.ui-sn[1].id ]
+
+  launch_template {
+    id      = aws_launch_template.ui-lt.id
+    version = "$Latest"
+  }
 
   target_group_arns     = [ aws_alb_target_group.ui-tg80-a.arn ]
   health_check_type     = "ELB"
 
-  min_size              = var.ui_lc.min_size
-  max_size              = var.ui_lc.max_size
+  min_size              = var.ui_lt.min_size
+  max_size              = var.ui_lt.max_size
 
   tag {
     key                 = "Name"

--- a/production/services/ui/vars.tf
+++ b/production/services/ui/vars.tf
@@ -58,10 +58,10 @@ variable "sg_cidr_block" {
 
 
 # ######################
-# Launch Configuration
+# Launch Template
 # ######################
-# ui launch configuration
-variable "ui_lc" {
-  description = "ui launch configuration"
+# ui launch template
+variable "ui_lt" {
+  description = "ui launch template"
   type = map(string)
 }

--- a/production/terraform.tfvars
+++ b/production/terraform.tfvars
@@ -81,7 +81,7 @@ sg_cidr_block = ["58.151.93.9/32", "58.151.93.2/32"]
 # ui launch template
 ui_lt = {
     "id" = "ami-0cd7b0de75f5a35d1" //"ami-0d69d26d777db7c18" (ui prod img)
-    "type" = "t3.medium"
+    "type" = "t3.small"
     "key_name" = "comp-prod-keypair"
     "min_size" = 0
     "max_size" = 0
@@ -90,7 +90,7 @@ ui_lt = {
 # api launch template
 api_lt = {
   "id" = "ami-0cd7b0de75f5a35d1" //"ami-036d0b92069714dd9" (api prod img)
-  "type" = "t3.medium"
+  "type" = "t3.small"
   "key_name" = "comp-prod-keypair"
   "min_size" = 0
   "max_size" = 0

--- a/production/terraform.tfvars
+++ b/production/terraform.tfvars
@@ -76,24 +76,24 @@ sg_cidr_block = ["58.151.93.9/32", "58.151.93.2/32"]
 
 
 # ######################
-# Launch Configuration
+# Launch Template
 # ######################
-# ui launch configuration
-ui_lc = {
-    "id" = "ami-0d69d26d777db7c18"
+# ui launch template
+ui_lt = {
+    "id" = "ami-0cd7b0de75f5a35d1" //"ami-0d69d26d777db7c18" (ui prod img)
     "type" = "t3.medium"
     "key_name" = "comp-prod-keypair"
-    "min_size" = 1
-    "max_size" = 3
+    "min_size" = 0
+    "max_size" = 0
 }
 
-# api launch configuration
-api_lc = {
-  "id" = "ami-036d0b92069714dd9"
+# api launch template
+api_lt = {
+  "id" = "ami-0cd7b0de75f5a35d1" //"ami-036d0b92069714dd9" (api prod img)
   "type" = "t3.medium"
   "key_name" = "comp-prod-keypair"
-  "min_size" = 1
-  "max_size" = 3
+  "min_size" = 0
+  "max_size" = 0
 }
 
 

--- a/production/variables.tf
+++ b/production/variables.tf
@@ -79,17 +79,17 @@ variable "sg_cidr_block" {
 
 
 # ######################
-# Launch Configuration
+# Launch Template
 # ######################
-# ui launch configuration
-variable "ui_lc" {
-  description = "ui launch configuration"
+# ui launch template
+variable "ui_lt" {
+  description = "ui launch template"
   type = map(string)
 }
 
-# api launch configuration
-variable "api_lc" {
-  description = "api launch configuration"
+# api launch template
+variable "api_lt" {
+  description = "api launch template"
   type = map(string)
 }
 

--- a/stage/main.tf
+++ b/stage/main.tf
@@ -82,7 +82,7 @@ module "ui" {
   sg_cidr_block = var.sg_cidr_block
 
   # lc
-  ui_lc = var.ui_lc
+  ui_lt = var.ui_lt
 }
 
 module "api" {
@@ -106,5 +106,5 @@ module "api" {
   sg_cidr_block = var.sg_cidr_block
 
   # lc
-  api_lc = var.api_lc
+  api_lt = var.api_lt
 }

--- a/stage/services/api/asg.tf
+++ b/stage/services/api/asg.tf
@@ -1,28 +1,32 @@
-resource "aws_launch_configuration" "api-lc" {
-  name            = "${var.resrc_prefix_nm}-api-lc"
-  image_id        = var.api_lc.id
-  instance_type   = var.api_lc.type
-  key_name        = var.api_lc.key_name
-  security_groups = [ aws_security_group.api-sg.id ]
+resource "aws_launch_template" "api-lt" {
+  name                    = "${var.resrc_prefix_nm}-api-lt"
+  image_id                = var.api_lt.id
+  key_name                = var.api_lt.key_name
+  instance_type           = var.api_lt.type
+  vpc_security_group_ids  = [ aws_security_group.api-sg.id ]
 
-  user_data = <<USER_DATA
-#!/bin/bash
-java -jar /home/ubuntu/backend-demo-1.0.0-SNAPSHOT.jar &
-  USER_DATA
-
-  lifecycle { create_before_destroy = true }
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      "Name" = "${var.resrc_prefix_nm}-api-lt"
+    }
+  }
 }
 
 resource "aws_autoscaling_group" "api-asg" {
   name                  = "${var.resrc_prefix_nm}-api-asg"
-  launch_configuration  = aws_launch_configuration.api-lc.id
   vpc_zone_identifier   = [ aws_subnet.api-sn[0].id, aws_subnet.api-sn[1].id ]
+
+  launch_template {
+    id      = aws_launch_template.api-lt.id
+    version = "$Latest"
+  }
 
   target_group_arns     = [ aws_alb_target_group.api-tg8080-a.arn ]
   health_check_type     = "ELB"
 
-  min_size              = var.api_lc.min_size
-  max_size              = var.api_lc.max_size
+  min_size              = var.api_lt.min_size
+  max_size              = var.api_lt.max_size
 
   tag {
     key                 = "Name"

--- a/stage/services/api/vars.tf
+++ b/stage/services/api/vars.tf
@@ -58,10 +58,10 @@ variable "sg_cidr_block" {
 
 
 # ######################
-# Launch Configuration
+# Launch Template
 # ######################
-# api launch configuration
-variable "api_lc" {
-  description = "api launch configuration"
+# api launch template
+variable "api_lt" {
+  description = "api launch template"
   type = map(string)
 }

--- a/stage/services/ui/asg.tf
+++ b/stage/services/ui/asg.tf
@@ -1,23 +1,32 @@
-resource "aws_launch_configuration" "ui-lc" {
-  name            = "${var.resrc_prefix_nm}-ui-lc"
-  image_id        = var.ui_lc.id
-  instance_type   = var.ui_lc.type
-  key_name        = var.ui_lc.key_name
-  security_groups = [ aws_security_group.ui-sg.id ]
+resource "aws_launch_template" "ui-lt" {
+  name                    = "${var.resrc_prefix_nm}-ui-lt"
+  image_id                = var.ui_lt.id
+  key_name                = var.ui_lt.key_name
+  instance_type           = var.ui_lt.type
+  vpc_security_group_ids  = [ aws_security_group.ui-sg.id ]
 
-  lifecycle { create_before_destroy = true }
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      "Name" = "${var.resrc_prefix_nm}-ui-lt"
+    }
+  }
 }
 
 resource "aws_autoscaling_group" "ui-asg" {
   name                  = "${var.resrc_prefix_nm}-ui-asg"
-  launch_configuration  = aws_launch_configuration.ui-lc.id
   vpc_zone_identifier   = [ aws_subnet.ui-sn[0].id, aws_subnet.ui-sn[1].id ]
+
+  launch_template {
+    id      = aws_launch_template.ui-lt.id
+    version = "$Latest"
+  }
 
   target_group_arns     = [ aws_alb_target_group.ui-tg80-a.arn ]
   health_check_type     = "ELB"
 
-  min_size              = var.ui_lc.min_size
-  max_size              = var.ui_lc.max_size
+  min_size              = var.ui_lt.min_size
+  max_size              = var.ui_lt.max_size
 
   tag {
     key                 = "Name"

--- a/stage/services/ui/vars.tf
+++ b/stage/services/ui/vars.tf
@@ -58,10 +58,10 @@ variable "sg_cidr_block" {
 
 
 # ######################
-# Launch Configuration
+# Launch Template
 # ######################
-# ui launch configuration
-variable "ui_lc" {
-  description = "ui launch configuration"
+# ui launch template
+variable "ui_lt" {
+  description = "ui launch template"
   type = map(string)
 }

--- a/stage/terraform.tfvars
+++ b/stage/terraform.tfvars
@@ -81,7 +81,7 @@ sg_cidr_block = ["58.151.93.9/32", "58.151.93.2/32"]
 # ui launch template
 ui_lt = {
     "id" = "ami-0cd7b0de75f5a35d1" // "ami-0740ca5a912ab5be6" (ui stg img)
-    "type" = "t3.medium"
+    "type" = "t3.small"
     "key_name" = "comp-prod-keypair"
     "min_size" = 0
     "max_size" = 0
@@ -90,7 +90,7 @@ ui_lt = {
 # api launch template
 api_lt = {
   "id" = "ami-0cd7b0de75f5a35d1" // "ami-00e46f0632d32c625" (api stg img)
-  "type" = "t3.medium"
+  "type" = "t3.small"
   "key_name" = "comp-prod-keypair"
   "min_size" = 0
   "max_size" = 0

--- a/stage/terraform.tfvars
+++ b/stage/terraform.tfvars
@@ -76,24 +76,24 @@ sg_cidr_block = ["58.151.93.9/32", "58.151.93.2/32"]
 
 
 # ######################
-# Launch Configuration
+# Launch Template
 # ######################
-# ui launch configuration
-ui_lc = {
-    "id" = "ami-0740ca5a912ab5be6"
+# ui launch template
+ui_lt = {
+    "id" = "ami-0cd7b0de75f5a35d1" // "ami-0740ca5a912ab5be6" (ui stg img)
     "type" = "t3.medium"
     "key_name" = "comp-prod-keypair"
-    "min_size" = 1
-    "max_size" = 1
+    "min_size" = 0
+    "max_size" = 0
 }
 
-# api launch configuration
-api_lc = {
-  "id" = "ami-00e46f0632d32c625"
+# api launch template
+api_lt = {
+  "id" = "ami-0cd7b0de75f5a35d1" // "ami-00e46f0632d32c625" (api stg img)
   "type" = "t3.medium"
   "key_name" = "comp-prod-keypair"
-  "min_size" = 1
-  "max_size" = 1
+  "min_size" = 0
+  "max_size" = 0
 }
 
 

--- a/stage/variables.tf
+++ b/stage/variables.tf
@@ -79,17 +79,17 @@ variable "sg_cidr_block" {
 
 
 # ######################
-# Launch Configuration
+# Launch Template
 # ######################
-# ui launch configuration
-variable "ui_lc" {
-  description = "ui launch configuration"
+# ui launch template
+variable "ui_lt" {
+  description = "ui launch template"
   type = map(string)
 }
 
-# api launch configuration
-variable "api_lc" {
-  description = "api launch configuration"
+# api launch template
+variable "api_lt" {
+  description = "api launch template"
   type = map(string)
 }
 


### PR DESCRIPTION
[Resolution]
- launch configuration > launch template 로 변경
- developmet 환경 : 테스트를 위해 min 1 max 2로 셋팅, image id 각각 ui와 api로 셋팅
- production, stage 환경 : auto scaling group의 min/max size를 0으로 셋팅
- production, stage 환경 : ui, api image id를 ubuntu 기본 id 로 변경

[DoD]
terraform init, plan, apply를 통해서 각 resource가 생성되는지 확인
jenkins를 통해 apply/destroy 확인

[Team]
Productivity Engineering

[Company]
BespinGlobal