### PR TITLE
[CMSA-392] [웅진 Demo앱] Backend app 무정지 배포 cicd 구성 - CodeDeploy

### DIFF
--- a/development/services/api/launch-template.tf
+++ b/development/services/api/launch-template.tf
@@ -9,6 +9,8 @@ resource "aws_launch_template" "api-lt" {
     name = "comp-codedeploy-ec2-role"
   }
 
+  user_data = base64encode(templatefile("./services/api/ud-startup-health.tpl", {}))
+
   tag_specifications {
     resource_type = "instance"
     tags = {


### PR DESCRIPTION
[Resolution]
launch-template 구성 및 ami 지정 완료

[DoD]
dev 환경을 대상으로 codedeploy 구성을 설정하고
jenkins cicd 또는 aws cli 를 통해 codedeploy app 및 deploymnet-group 에 demo-api 서비스가 배포됨을 데모를 통해 확인

[Team] Productivity Engineering
[Company] BespinGlobal